### PR TITLE
Bump compileSdk and targetSdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace = "top.wxx9248.splitapkinstaller"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "top.wxx9248.splitapkinstaller"
         minSdk = 33
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 3
         versionName = "1.2.0"
 
@@ -49,7 +49,6 @@ android {
     buildFeatures {
         compose = true
     }
-    compileSdkMinor = 1
     ndkVersion = "29.0.14206865"
 }
 


### PR DESCRIPTION
## Summary
- Updated `compileSdk` from 36(.1) to 37 and `targetSdk` from 36 to 37 in `app/build.gradle.kts`.
- Dropped `compileSdkMinor = 1`, which targeted API 36.1 specifically.

## Why
Every open dependency-bump PR (#97-#102) was failing `checkDebugAarMetadata` because updated `androidx` releases (e.g. `androidx.lifecycle:lifecycle-viewmodel-compose-android:2.11.0`) require compiling against API 37 or later, while the project was still on 36.1.

## Test plan
- [ ] CI (`build-debug`) passes on this PR
- [ ] The 6 blocked dependency-bump PRs go green once rebased onto this